### PR TITLE
Allow base <4.14, bump to version 0.2.0.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for iterm-show-JuicyPixels
 
+## 0.2.0.0  -- 2018-04-03
+
+* Allow base <4.14 for GHC 8.8
+
 ## 0.1.0.0  -- 2018-10-10
 
 * Provides Show instances for images that are PngSavable

--- a/iterm-show-JuicyPixels.cabal
+++ b/iterm-show-JuicyPixels.cabal
@@ -1,5 +1,5 @@
 name:                iterm-show-JuicyPixels
-version:             0.1.0.0
+version:             0.2.0.0
 synopsis:            Orphan Show instances for JuciyPixels image types.
 description:
   This package provides Show instances for graphical types in JuicyPixels.
@@ -22,6 +22,6 @@ source-repository head
 
 library
   exposed-modules:     ITermShow.JuicyPixels
-  build-depends:       base >=4.9 && <4.13, iterm-show, JuicyPixels
+  build-depends:       base >=4.9 && <4.14, iterm-show, JuicyPixels
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/iterm-show-JuicyPixels.nix
+++ b/iterm-show-JuicyPixels.nix
@@ -1,7 +1,7 @@
 { mkDerivation, base, iterm-show, JuicyPixels, stdenv }:
 mkDerivation {
   pname = "iterm-show-JuicyPixels";
-  version = "0.1.0.0";
+  version = "0.2.0.0";
   src = ./.;
   libraryHaskellDepends = [ base iterm-show JuicyPixels ];
   description = "Orphan Show instances for JuciyPixels image types";


### PR DESCRIPTION
Addresses Issue #1.